### PR TITLE
Update ng-magnify.js

### DIFF
--- a/src/js/ng-magnify.js
+++ b/src/js/ng-magnify.js
@@ -112,7 +112,7 @@
 
         scope.getGlassStyle = function () {
           return {
-            background: 'url(' + scope.imageSrc + ') no-repeat',
+            background: 'url("' + scope.imageSrc + '") no-repeat',
             width: (scope.glassWidth) ? scope.glassWidth + 'px' : '',
             height: (scope.glassHeight) ? scope.glassHeight + 'px' : ''
           };


### PR DESCRIPTION
Need quotes around URL to work with electron file URLs e.g. `file:///Users/petah/Library/Application%20Support/Electron/assets/0d059399ecbf58e3cb41072ecf534369.jpg`

Otherwise it triggers "Not allowed to load local resource" error.
